### PR TITLE
Tested shell script to read temperature from LM75B

### DIFF
--- a/bin/papirus-temp
+++ b/bin/papirus-temp
@@ -14,7 +14,7 @@ ib=$(echo "obase=2;$ia" | bc)
 ic="${ib:0:-5}"
 [ $DEBUG ] && echo "IC is ${ic}"
 # if binary value is 11 bits long, number is negative (twos complement)
-if [ $(echo "${ic}" | wc -c) -eq 11 ]
+if [ $(echo "${ic}" | wc -c) -eq 12 ]
 then
     [ $DEBUG ] && echo "Temperature is negative"
     ica=$(echo "ibase=2;${ic}" | bc)
@@ -24,4 +24,5 @@ else
 fi
 [ $DEBUG ] && echo "ID is ${id}"
 ie=$(echo "scale=3;${id}*0.125" | bc)
-echo "Temp is ${ie} deg C."
+if=$(echo "scale=3;${ie}*1.8+32" | bc)
+echo "Temp is ${ie} deg C (${if} deg F)."

--- a/bin/papirus-temp
+++ b/bin/papirus-temp
@@ -14,7 +14,7 @@ ib=$(echo "obase=2;$ia" | bc)
 ic="${ib:0:-5}"
 [ $DEBUG ] && echo "IC is ${ic}"
 # if binary value is 11 bits long, number is negative (twos complement)
-if [ $(echo "${ic}" | wc -c) -eq 12 ]
+if [ $(echo -en "${ic}" | wc -c) -eq 11 ]
 then
     [ $DEBUG ] && echo "Temperature is negative"
     ica=$(echo "ibase=2;${ic}" | bc)


### PR DESCRIPTION
Need to enable i2c for this.
```bash
pi@raspberrypi:~ $ bin/papirus-temp
Temp is -7.125 deg C (19.175 deg F).
pi@raspberrypi:~ $ while true;do bin/papirus-temp;sleep 5;done
Temp is -5.875 deg C (21.425 deg F).
Temp is -5.125 deg C (22.775 deg F).
Temp is -4.375 deg C (24.125 deg F).
Temp is -3.750 deg C (25.250 deg F).
Temp is -3.125 deg C (26.375 deg F).
Temp is -2.500 deg C (27.500 deg F).
Temp is -2.125 deg C (28.175 deg F).
Temp is -1.625 deg C (29.075 deg F).
Temp is -1.250 deg C (29.750 deg F).
Temp is -.500 deg C (31.100 deg F).
Temp is -.125 deg C (31.775 deg F).
Temp is .375 deg C (32.675 deg F).
Temp is .875 deg C (33.575 deg F).
Temp is 1.125 deg C (34.025 deg F).
Temp is 1.625 deg C (34.925 deg F).
Temp is 1.875 deg C (35.375 deg F).
Temp is 2.500 deg C (36.500 deg F).
```