### PR TITLE
install package for papirus-temp

### DIFF
--- a/install
+++ b/install
@@ -4,6 +4,9 @@
 sudo apt-get install git -y
 sudo apt-get install python-imaging -y
 
+# packages needed by papirus-temp
+sudo apt-get install bc i2c-tools -y
+
 git clone https://github.com/PiSupply/PaPiRus.git
 cd PaPiRus
 sudo python setup.py install    # Install PaPirRus python library


### PR DESCRIPTION
Added command to install "bc" and "i2c-tools" packages needed by papirus-temp.
(i hope this is the right file and place to add package installation lines)
papirus-temp print temperature on shell using papirus hat temperature sensor.