### PR TITLE
Fix config driver enable logic

### DIFF
--- a/bin/papirus-config
+++ b/bin/papirus-config
@@ -5,7 +5,7 @@ OPTION=$(whiptail --title "PaPiRus Config" --menu "Choose an option" 22 78 16 \
 "Enable Driver" "Enable and disable the ePaper driver." \
 "Mirror Framebuffer" "Use ePaper as a general display." \
 "Web Interface" "Enable the web interface." \
-"Test Mode" "Enable auto test when HAT is plugged in." 3>&1 1>&2 2>&3)		
+"Test Mode" "Enable auto test when HAT is plugged in." 3>&1 1>&2 2>&3)
 
 exitstatus=$?
 if [ $exitstatus = 0 ]; then
@@ -23,7 +23,7 @@ if [ "$OPTION" = "Screen Size" ]; then
 	"2.0" "Inch                    " OFF \
 	"2.6" "Inch                    " OFF \
 	"2.7" "Inch                    " OFF 3>&1 1>&2 2>&3)
-	 
+
 	exitstatus=$?
 	if [ $exitstatus = 0 ]; then
 	    papirus-set $DISTROS
@@ -35,11 +35,11 @@ if [ "$OPTION" = "Enable Driver" ]; then
 
 	#!/bin/bash
 	if (whiptail --title "Enable Driver" --yes-button "Enable" --no-button "Disable"  --yesno "Enable or disable the ePaper driver" 10 60) then
-	    service epd-fuse stop
-	    update-rc.d epd-fuse disable
-	else
-	    update-rc.d epd-fuse enable
+        update-rc.d epd-fuse enable
 	    service epd-fuse start
+	else
+        service epd-fuse stop
+	    update-rc.d epd-fuse disable
 	fi
 
 fi

--- a/bin/papirus-config
+++ b/bin/papirus-config
@@ -2,7 +2,7 @@
 
 OPTION=$(whiptail --title "PaPiRus Config" --menu "Choose an option" 22 78 16 \
 "Screen Size" "Change the screen ePaper screen size." \
-"Enable Driver" "Enable and disable the ePaper driver." \
+"ePaper Driver" "Enable and disable the ePaper driver." \
 "Mirror Framebuffer" "Use ePaper as a general display." \
 "Web Interface" "Enable the web interface." \
 "Test Mode" "Enable auto test when HAT is plugged in." 3>&1 1>&2 2>&3)
@@ -31,10 +31,10 @@ if [ "$OPTION" = "Screen Size" ]; then
 
 fi
 
-if [ "$OPTION" = "Enable Driver" ]; then
+if [ "$OPTION" = "ePaper Driver" ]; then
 
 	#!/bin/bash
-	if (whiptail --title "Enable Driver" --yes-button "Enable" --no-button "Disable"  --yesno "Enable or disable the ePaper driver" 10 60) then
+	if (whiptail --title "ePaper Driver" --yes-button "Enable" --no-button "Disable"  --yesno "Enable or disable the ePaper driver" 10 60) then
         update-rc.d epd-fuse enable
 	    service epd-fuse start
 	else


### PR DESCRIPTION
Fixed the papirus-config script driver enable/disable logic (they were the wrong way round), and disambiguates the driver menu text so that it doesn’t output “Enable Driver” to the terminal even when you intention is to disable the driver.