### PR TITLE
papirus-write complained about missing parentheses

### DIFF
--- a/bin/papirus-clock
+++ b/bin/papirus-clock
@@ -27,7 +27,7 @@ from papirus import Papirus
 
 user = os.getuid()
 if user != 0:
-    print "Please run script as root"
+    print ("Please run script as root")
     sys.exit()
     
 WHITE = 1

--- a/bin/papirus-write
+++ b/bin/papirus-write
@@ -10,7 +10,7 @@ import argparse
 
 user = os.getuid()
 if user != 0:
-    print "Please run script as root"
+    print ("Please run script as root")
     sys.exit()
 
 # Command line usage


### PR DESCRIPTION
It wouldn't run without this change, tested on a brand new Raspbian card