### PR TITLE
Initial unicode support for Text and TextPos

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,18 @@ text.RemoveText("Top")
 text.WriteAll()
 ```
 
+#### Unicode Support in the Text API
+```python
+from papirus import PapirusText
+
+text = PapirusText()
+
+# Write text to the screen, in this case forty stars alternating black and white
+# note the use of u"" syntax to specify unicode
+text.write(u"\u2605 \u2606 \u2605 \u2606 \u2605 \u2606 \u2605 \u2606 \u2605 \u2606 \u2605 \u2606 \u2605 \u2606 \u2605 \u2606 \u2605 \u2606 \u2605 \u2606 \u2605 \u2606 \u2605 \u2606 \u2605 \u2606 \u2605 \u2606 \u2605 \u2606 \u2605 \u2606 \u2605 \u2606 \u2605 \u2606 \u2605 \u2606 \u2605 \u2606")
+```
+Note: the default font, FreeMono, has [limited unicode support](http://www.fileformat.info/info/unicode/font/freemono/blocklist.htm), so you may want to specify an alternate font to use a fuller range characters.
+
 #### The Image API
 ```python
 from papirus import PapirusImage

--- a/papirus/text.py
+++ b/papirus/text.py
@@ -27,7 +27,8 @@ class PapirusText():
         line_size = (self.papirus.width / (size*0.65))
 
         current_line = 0
-        text_lines = [""]
+        # unicode by default
+        text_lines = [u""]
 
         # Compute each line
         for word in text.split():

--- a/papirus/textpos.py
+++ b/papirus/textpos.py
@@ -35,7 +35,7 @@ class PapirusTextPos():
 
         # If the Id doesn't exist, add it  to the dictionary
 	if Id not in self.allText:
-            self.allText[Id] = DispText(text.decode('string_escape'), x, y, size)
+            self.allText[Id] = DispText(text, x, y, size)
             # add the text to the image
             self.addToImageText(Id, font_path)
             #Automatically show?
@@ -91,7 +91,8 @@ class PapirusTextPos():
 
         # Starting vars
         current_line = 0
-        text_lines = []
+        # unicode by default
+        text_lines = [u""]
 
         # Split the text by \n first
         toProcess = self.allText[Id].text.splitlines()


### PR DESCRIPTION
See line 38 of papirus/textpos.py - I am not sure why we are using `decode('string_escape')` but it is not utf-8 friendly. All tests seem to work fine without it. Please advise before merging.