### PR TITLE
Use lm75b option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ screen.update()
 # Update only the changed pixels (faster)
 screen.partial_update()
 
+# Disable automatic use of LM75B temperature sensor
+screen.use_lm75b = False
+
 # Change screen size
 # SCREEN SIZES 1_44INCH | 1_9INCH | 2_0INCH | 2_6INCH | 2_7INCH
 screen.set_size(papirus.2_7INCH) (coming soon)
@@ -234,6 +237,9 @@ papirus-buttons
 
 # Demo of getting temperature from LM75
 papirus-temp
+
+# Demo showing depdency of update rate on temperature
+papirus-radar
 
 # Snakes game
 papirus-snakes (coming soon)

--- a/bin/papirus-radar
+++ b/bin/papirus-radar
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+
+# Demo showing the dependency of frame update duration on temperature
+#
+# Fastest update is with temperature set to > 60, but ghosting is evident.
+# Lower temperatures give blacker updates, with less ghosting.
+# By not using the LM75B temperature sensor, we can fake the temperature by
+# writing to /dev/epd/termperature 
+#
+# This demo is a modified version of David Lowe's original demo (https://github.com/campag/eink-demo)
+# Best results with the epd driver with continous temperature compensation.
+
+import thread
+import string
+import time
+import sys
+
+from datetime import datetime, timedelta
+from subprocess import call, check_output
+from PIL import Image
+from PIL import ImageDraw, ImageFont
+from papirus import Papirus
+
+epd = Papirus()
+
+SCREEN_WIDTH  = epd.size[0]
+SCREEN_HEIGHT = epd.size[1]
+
+SCREEN_WIDTH-=1
+SCREEN_HEIGHT-=1
+
+FONTFILE = '/usr/share/fonts/truetype/freefont/FreeMonoBold.ttf'
+
+SIZE_MED = int(SCREEN_HEIGHT/4)  #24
+FONT_MED = ImageFont.truetype(FONTFILE, SIZE_MED)
+CHRW_MED = FONT_MED.getsize("0")[0]
+
+WHITE = 1
+BLACK = 0
+
+DURATION = 15 # seconds
+
+image = Image.new('1', epd.size, WHITE)
+draw = ImageDraw.Draw(image)
+
+def epd_draw(lagtime, packet_num):
+
+    # Clear drawing
+    draw.rectangle([(0,0), (SCREEN_WIDTH, SCREEN_HEIGHT)], fill=WHITE, outline=WHITE)
+
+    # Draw radar
+    draw.ellipse([((SCREEN_WIDTH-SCREEN_HEIGHT)/2,0),(SCREEN_HEIGHT+(SCREEN_WIDTH-SCREEN_HEIGHT)/2, SCREEN_HEIGHT)], outline=BLACK)
+    draw.pieslice([((SCREEN_WIDTH-SCREEN_HEIGHT)/2,0),(SCREEN_HEIGHT+(SCREEN_WIDTH-SCREEN_HEIGHT)/2, SCREEN_HEIGHT)], 10*packet_num-2, 10*packet_num+2, fill=BLACK)
+
+    # Temperature & seconds counter
+    temp=check_output(["cat", "/dev/epd/temperature"])
+    temp=temp[:-1]+u'\u00b0C'
+    now = datetime.today()
+    draw.text((SCREEN_WIDTH/2-5.0*CHRW_MED, SCREEN_HEIGHT/2-1.5*SIZE_MED), "%s %02ds" %(temp, now.second), fill=BLACK, font=FONT_MED)
+
+    # fps
+    fps10x=10000/lagtime
+    draw.text((SCREEN_WIDTH/2-3.0*CHRW_MED, SCREEN_HEIGHT/2-0.5*SIZE_MED), "%3dfps" %fps10x, fill=BLACK, font=FONT_MED)
+    draw.text((SCREEN_WIDTH/2-1.4*CHRW_MED, SCREEN_HEIGHT/2-0.5*SIZE_MED), ".", fill=BLACK, font=FONT_MED)
+
+    # Cycle time
+    draw.text((SCREEN_WIDTH/2-2.5*CHRW_MED, SCREEN_HEIGHT/2+0.5*SIZE_MED), "%3dms" %lagtime, fill=BLACK, font=FONT_MED)
+
+    # Swap rendered image to epd image buffer
+    epd.display(image)
+    if lagtime > 0:
+        epd.partial_update()
+
+    return
+
+# Main entry
+
+temps = [25, 35, 45, 55, 65]
+for temp in temps:
+
+    epd.use_lm75b = True
+    epd.clear()
+
+    epd.use_lm75b = False
+    # Set temperature
+    cmd = "echo " + str(temp) + " > /dev/epd/temperature"
+    call([cmd], shell=True)
+
+    counter=0
+    frametime=-1  # No screen update for first frame
+
+    try:
+        starttime = datetime.now()
+        delta = timedelta(seconds = DURATION)
+        while (True):
+            prev=datetime.now()
+            epd_draw(frametime,counter)
+            curr=datetime.now()
+            if (curr - starttime) > delta:
+                break
+            frametime=(curr-prev).seconds*1000 + (curr - prev).microseconds/1000
+            counter += 1
+    except KeyboardInterrupt:
+        print "\nClearing panel for long term storage"
+        epd.use_lm75b = True
+        epd.clear()
+        epd.clear()
+        sys.exit('\nKeyboard interrupt')
+
+epd.use_lm75b = True
+epd.clear()
+epd.clear()

--- a/bin/papirus-temp
+++ b/bin/papirus-temp
@@ -23,7 +23,7 @@ else
     id=$(echo "ibase=2;${ic}" | bc)
 fi
 [ $DEBUG ] && echo "ID is ${id}"
-ie=$(echo "scale=3;${id}*0.125" | bc)
-if=$(echo "scale=3;${ie}*1.8+32" | bc)
+ie=$(echo "scale=1;(${id}*0.125)*10/10" | bc)
+if=$(echo "scale=1;${ie}*1.8+32" | bc)
 echo "Temp is ${ie} deg C (${if} deg F)."
-papirus-write "Temp is ${ie} deg C (${if} deg F)."
+papirus-write "Temp is ${ie}\\xb0C (${if}\\xb0F)."

--- a/papirus/epd.py
+++ b/papirus/epd.py
@@ -56,6 +56,7 @@ to use:
         self._film = 0
         self._auto = False
         self._lm75b = LM75B()
+        self._uselm75b = True
 
         if len(args) > 0:
             self._epd_path = args[0]
@@ -122,6 +123,17 @@ to use:
         else:
             self._auto = False
 
+    @property
+    def use_lm75b(self):
+        return self._uselm75b
+
+    @use_lm75b.setter
+    def use_lm75b(self, flag):
+        if flag:
+            self._uselm75b = True
+        else:
+            self._uselm75b = False
+
     def error_status(self):
         with open(os.path.join(self._epd_path, 'error'), 'r') as f:
             return(f.readline().rstrip('\n'))
@@ -157,7 +169,8 @@ to use:
         self._command('C')
 
     def _command(self, c):
-        with open(os.path.join(self._epd_path, 'temperature'), 'wb') as f:
-            f.write(repr(self._lm75b.getTempC()))
+        if self._uselm75b:
+            with open(os.path.join(self._epd_path, 'temperature'), 'wb') as f:
+                f.write(repr(self._lm75b.getTempC()))
         with open(os.path.join(self._epd_path, 'command'), 'wb') as f:
             f.write(c)


### PR DESCRIPTION
Make use of lm75b temperature sensor optional.
Added papirus-radar demo showing the dependency of update rate on temperature.
This is a modified version of David Lowe's original demo (https://github.com/campag/eink-demo).
Best results with the modified epd driver from David Lowe (https://github.com/campag/gratis).
Will submit a separate PR to repaper/gratis repository with David Lowe's changes.