### PR TITLE
Remove test code from papirus-draw

### DIFF
--- a/bin/papirus-draw
+++ b/bin/papirus-draw
@@ -35,14 +35,7 @@ def main():
     papirus = Papirus(rotation = args.rotate)
     if args.filepath:
         print("Drawing on PaPiRus.......")
-        for i in range(0, 5):
-            print("Rotation = " + str(papirus.rotation))
-            draw_image(papirus, args.filepath, args.type)
-            time.sleep(2)
-            if papirus.rotation == 270:
-                papirus.rotation = 0
-            else:
-                papirus.rotation = papirus.rotation + 90 
+        draw_image(papirus, args.filepath, args.type)
 
 def draw_image(papirus, filepath, type):
     message = ""


### PR DESCRIPTION
papirus-draw now draws the image only once.

Previously the image was drawn five times: once at each rotation, and finally at the requested rotation