### PR TITLE
fonts-freefont-ttf is needed as dependancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ apt-get install python-imaging -y
 apt-get install python-smbus -y
 apt-get install bc i2c-tools -y
 apt-get install python-dateutil -y
+apt-get install fonts-freefont-ttf -y
 
 git clone https://github.com/PiSupply/PaPiRus.git
 cd PaPiRus


### PR DESCRIPTION
when doing a manual install I noticed the text api did not work,
turned out the font was missing  :)