### PR TITLE
utf-8 strings need to be encoded to work from cron

### DIFF
--- a/bin/papirus-temp
+++ b/bin/papirus-temp
@@ -53,7 +53,7 @@ def main(argv):
     sensor = LM75B()
     tempC = '{c:.2f}'.format(c=sensor.getTempCFloat()) + u" \u00b0" + 'C'
     tempF = '{c:.2f}'.format(c=sensor.getTempFFloat()) + u" \u00b0" + 'F'
-    print('Temperature from LM75B: ' + tempC + ' - ' + tempF)
+    print(('Temperature from LM75B: ' + tempC + ' - ' + tempF).encode('utf8'))
 
     # center the temperatures
     (txtwidth, txtheight) = draw.textsize(tempC, font=font)

--- a/bin/papirus-temp
+++ b/bin/papirus-temp
@@ -53,7 +53,7 @@ def main(argv):
     sensor = LM75B()
     tempC = '{c:.2f}'.format(c=sensor.getTempCFloat()) + u" \u00b0" + 'C'
     tempF = '{c:.2f}'.format(c=sensor.getTempFFloat()) + u" \u00b0" + 'F'
-    print(('Temperature from LM75B: ' + tempC + ' - ' + tempF).encode('utf8'))
+    print(('Temperature from LM75B: ' + tempC + ' - ' + tempF).encode('utf-8'))
 
     # center the temperatures
     (txtwidth, txtheight) = draw.textsize(tempC, font=font)


### PR DESCRIPTION
Wanted to call the papirus-temp from cron, but nothing happened.
so, ran bash like cron with: env -i /bin/bash --noprofile --norc
to see what happens when running papirus-temp.
got: UnicodeEncodeError: 'ascii' codec can't encode character u'\xb0' in position 30: ordinal not in range(128)
aha, cron talks ascii 😄 