### PR TITLE
Add ability to pipe images into stdin in papirus-draw

### DIFF
--- a/bin/papirus-draw
+++ b/bin/papirus-draw
@@ -7,6 +7,7 @@ import sys
 import time
 from papirus import Papirus
 from PIL import Image
+import StringIO
 import argparse
 
 # Command line usage
@@ -44,8 +45,16 @@ def draw_image(papirus, filepath, type):
     # padding for placing the image
     xpadding = 0
     ypadding = 0
-    # open the image to display
-    file = Image.open(filepath)
+    # check whether to load the image from stdin or fs
+    if (filepath == "-"):
+        # load the image to display from stdin
+        image_stdin = ""
+        for line in sys.stdin:
+            image_stdin += line
+        file = Image.open(StringIO.StringIO(image_stdin))
+    else:
+        # open the image to display
+        file = Image.open(filepath)
     # display with crop option
     if type == "crop":
         # Landscape image

--- a/bin/papirus-draw
+++ b/bin/papirus-draw
@@ -7,8 +7,8 @@ import sys
 import time
 from papirus import Papirus
 from PIL import Image
-import StringIO
 import argparse
+from io import BytesIO
 
 # Command line usage
 # papirus-draw "filepath" -t "crop|resize"
@@ -47,14 +47,13 @@ def draw_image(papirus, filepath, type):
     ypadding = 0
     # check whether to load the image from stdin or fs
     if (filepath == "-"):
-        # load the image to display from stdin
-        image_stdin = ""
-        for line in sys.stdin:
-            image_stdin += line
-        file = Image.open(StringIO.StringIO(image_stdin))
+        # load the image from stdin
+        image = BytesIO(read_stdin())
     else:
-        # open the image to display
-        file = Image.open(filepath)
+        # load the image from fs
+        image = filepath
+    # open the image to display
+    file = Image.open(image)
     # display with crop option
     if type == "crop":
         # Landscape image
@@ -85,6 +84,14 @@ def draw_image(papirus, filepath, type):
     papirus.display(image)
     papirus.update()
     print(message)
+
+def read_stdin():
+    # Handle stdin differences between
+    if sys.version_info >= (3, 0):
+        stdin = sys.stdin.buffer
+    else:
+        stdin = sys.stdin
+    return stdin.read()
 
 if __name__ == '__main__':
     main()

--- a/bin/papirus-draw
+++ b/bin/papirus-draw
@@ -86,7 +86,7 @@ def draw_image(papirus, filepath, type):
     print(message)
 
 def read_stdin():
-    # Handle stdin differences between
+    # Handle stdin differences between python2 and python3
     if sys.version_info >= (3, 0):
         stdin = sys.stdin.buffer
     else:


### PR DESCRIPTION
Follows Unix philosophy of using output of one program as input to another program.

Allows simple one-liners such as the following:
`curl https://raw.githubusercontent.com/PiSupply/PaPiRus/master/bitmaps/papirus-logo.bmp | papirus-draw - -t resize`