### PR TITLE
feat: make it pip compatible

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,21 @@
+name: Python Flake8
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.8
+    - name: Setup flake8 annotations
+      uses: rbialon/flake8-annotations@v1
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        flake8 . --count --max-complexity=10 --statistics

--- a/.github/workflows/publish-to-pypi-test.yml
+++ b/.github/workflows/publish-to-pypi-test.yml
@@ -1,0 +1,36 @@
+name: Publish Python 🐍 distribution 📦 to TestPyPI
+
+on: [push]
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distribution 📦 to TestPyPI
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+
+      - name: Install pypa/build
+        run: |
+          python -m pip install build --user
+
+      - name: Build a binary wheel and a source tarball
+        run: |
+          python -m build --sdist --wheel --outdir dist/ .
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: ./dist/*
+
+      - name: Publish distribution 📦 to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+        if: github.ref == 'refs/heads/master'

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,54 @@
+name: Publish Python 🐍 distribution 📦 to PyPI
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distribution 📦 to PyPI
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+
+      - name: Install pypa/build
+        run: |
+          python -m pip install build --user
+
+      - name: Build a binary wheel and a source tarball
+        run: |
+          python -m build --sdist --wheel --outdir dist/ .
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: ./dist/*
+
+      - name: Get Latest Release
+        id: latest_version
+        uses: abatilo/release-info-action@v1.3.2
+        with:
+          owner: PiSupply
+          repo: PaPiRus
+
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./dist/*
+          tag: ${{ steps.latest_version.outputs.latest_tag }}
+          overwrite: true
+          file_glob: true
+
+      - name: Publish distribution 📦 to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/papirus/__init__.py
+++ b/papirus/__init__.py
@@ -1,4 +1,3 @@
-__version__ = '1.0.0'
 from papirus.lm75b import LM75B
 from papirus.epd import EPD as Papirus
 from papirus.text import PapirusText

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 #! /usr/bin/env python
 
 from distutils.core import setup
-import papirus
 
 setup(name='papirus',
-      version=papirus.__version__,
+      version='1.0.0',
       description="PaPiRus API",
       author='PiSupply',
       author_email='sales@pi-supply.com',


### PR DESCRIPTION
# Summary
This PR makes the package pip compatible.

# How I tested
I ran :
`pip install git+https://github.com/Minipada/PaPiRus.git@pip`

Tested on:
* PC X86_64: python 3.7.4.
* Cross compilation for raspberry pi 0 W with Yocto Zeus 

Installed files (output of the tree command):
```
└── usr
    ├── bin
    │   ├── papirus-animation
    │   ├── papirus-buttons
    │   ├── papirus-cam
    │   ├── papirus-clear
    │   ├── papirus-clock
    │   ├── papirus-composite-write
    │   ├── papirus-config
    │   ├── papirus-draw
    │   ├── papirus-fbcopy
    │   ├── papirus-gol
    │   ├── papirus-radar
    │   ├── papirus-set
    │   ├── papirus-setup
    │   ├── papirus-snake
    │   ├── papirus-system
    │   ├── papirus-temp
    │   ├── papirus-test
    │   ├── papirus-textfill
    │   ├── papirus-twitter
    │   └── papirus-write
    ├── lib
    │   └── python3.7
    │       └── site-packages
    │           ├── papirus
    │           │   ├── __init__.py
    │           │   ├── __pycache__
    │           │   │   ├── __init__.cpython-37.pyc
    │           │   │   ├── composite.cpython-37.pyc
    │           │   │   ├── epd.cpython-37.pyc
    │           │   │   ├── image.cpython-37.pyc
    │           │   │   ├── lm75b.cpython-37.pyc
    │           │   │   ├── readrtc.cpython-37.pyc
    │           │   │   ├── text.cpython-37.pyc
    │           │   │   └── textpos.cpython-37.pyc
    │           │   ├── composite.py
    │           │   ├── epd.py
    │           │   ├── image.py
    │           │   ├── lm75b.py
    │           │   ├── readrtc.py
    │           │   ├── text.py
    │           │   └── textpos.py
    │           └── papirus-1.0.0-py3.7.egg-info
    └── share
        └── bitmaps
            ├── 0.gif
            ├── 1.gif
            ├── 10.gif
            ├── 11.gif
            ├── 12.gif
            ├── 13.gif
            ├── 14.gif
            ├── 15.gif
            ├── 2.gif
            ├── 3.gif
            ├── 4.gif
            ├── 5.gif
            ├── 6.gif
            ├── 7.gif
            ├── 8.gif
            ├── 9.gif
            ├── papirus-cam-intro.jpg
            ├── papirus-logo.bmp
            └── python.png

9 directories, 56 files
```

resolves #128
